### PR TITLE
added max warnings to lintnf

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint src/",
-    "lintnf": "vue-cli-service lint src/ --no-fix"
+    "lintnf": "vue-cli-service lint src/ --no-fix --max-warnings"
   },
   "dependencies": {
     "@types/file-saver": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint src/",
-    "lintnf": "vue-cli-service lint src/ --no-fix --max-warnings"
+    "lintnf": "vue-cli-service lint src/ --no-fix --max-warnings 1"
   },
   "dependencies": {
     "@types/file-saver": "^2.0.0",


### PR DESCRIPTION
## What issue did you implement or fix?
Fixes #213 

## Summary
- Added maximum warnings to $ yarn lint in order for github actions to fail so we can keep the warnings in the linter

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update