### PR TITLE
BUG/249/Able to see the right values for ISBN and Type

### DIFF
--- a/frontend/src/components/TitleListComponent.vue
+++ b/frontend/src/components/TitleListComponent.vue
@@ -23,8 +23,8 @@ export default class TitleListComponent extends Vue {
   private headers: object[] = [
     { text: 'Titel', value: 'name', sortable: false },
     { text: 'Kostnad', value: 'cost', sortable: false },
-    { text: 'Typ', values: 'title_type', sortable: false },
-    { text: 'ISBN', values: 'isbn', sortable: false },
+    { text: 'Typ', value: 'title_type', sortable: false },
+    { text: 'ISBN', value: 'isbn', sortable: false },
   ];
 }
 </script>


### PR DESCRIPTION
## What issue did you implement or fix?
Fixes #249 

## Summary
You can now see the ISBN and type on Title page