### PR TITLE
You can now see the loans where you are the loaner.

### DIFF
--- a/frontend/src/components/LoanListComponent.vue
+++ b/frontend/src/components/LoanListComponent.vue
@@ -16,10 +16,10 @@ import { VuexModule } from 'vuex-module-decorators';
 export default class LoanListComponent extends Vue {
   private loansModule: VuexModule = LoansModule;
   private headers: object[] = [
-    { text: 'Lånad av', key: 'loaned_by.name', sortable: false },
-    { text: 'Utlånad av', key: 'lent_by.name', sortable: false },
-    { text: 'Boktitel', key: 'book.title.name', sortable: false },
-    { text: 'Utgångsdatum', key: 'expiration_date', sortable: false },
+    { text: 'Lånad av', value: 'loaned_by.name', sortable: false },
+    { text: 'Utlånad av', value: 'lent_by.name', sortable: false },
+    { text: 'Boktitel', value: 'book.title.name', sortable: false },
+    { text: 'Utgångsdatum', value: 'expiration_date', sortable: false },
   ];
 }
 </script>


### PR DESCRIPTION
## What issue did you implement or fix?
Fixes #250 

## Summary
- You can now see your own loans everywhere were 'LoanListComponent' is referenced.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## How can this implementation be improved?
- On the start page it doesn't show your loans in the beginning, but if you go to another page and then back it shows up. This is a problem for future someone.
- You can loan books to yourself, this is a problem for the future.