### PR TITLE
Feature/267 fixtures should work like snapshots

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -47,35 +47,78 @@ loan_cc.book = book_cc
 loan_cc.returned_at = Date.current
 loan_cc.save
 
-book_alice.dump_fixture(append=false)
-title_alice.dump_fixture(append=false)
-title_cc.dump_fixture
-title_lotr.dump_fixture
-title_tomtens_jul.dump_fixture
-
 review_alice = Review.new(score: 3, review: "I didn't particulary like this book.")
 review_alice.title = title_alice
 review_alice.user = loan_alice.loaned_by
 review_alice.save
-review_alice.dump_fixture(append=false)
+
 
 # Create the rest of the books
-Book.create(barcode: "5002", status: "Broken", title: title_alice).dump_fixture
-Book.create(barcode: "5003", status: "OK", title: title_alice).dump_fixture
-Book.create(barcode: "5004", status: "OK", title: title_lotr).dump_fixture
-Book.create(barcode: "5005", status: "Broken", title: title_lotr).dump_fixture
-Book.create(barcode: "5006", status: "OK", title: title_cc).dump_fixture
-Book.create(barcode: "5007", status: "OK", title: title_tomtens_jul).dump_fixture
-Book.create(barcode: "5008", status: "OK", title: title_tomtens_jul).dump_fixture
+Book.create(barcode: "5002", status: "Broken", title: title_alice)
+Book.create(barcode: "5003", status: "OK", title: title_alice)
+Book.create(barcode: "5004", status: "OK", title: title_lotr)
+Book.create(barcode: "5005", status: "Broken", title: title_lotr)
+Book.create(barcode: "5006", status: "OK", title: title_cc)
+Book.create(barcode: "5007", status: "OK", title: title_tomtens_jul)
+Book.create(barcode: "5008", status: "OK", title: title_tomtens_jul)
 
 # Create fixtures
-loan_alice.dump_fixture(append=false)
-loan_alice.lent_by.dump_fixture(append=false)
-loan_alice.loaned_by.dump_fixture(append=true)
+def fixtures_title()
+    titles = Title.all.to_a
+    titles.shift.dump_fixture(append = false)
+    for title in titles do
+        title.dump_fixture
+    end
+end
 
-loan_cc.dump_fixture
-loan_cc.loaned_by.dump_fixture
+def fixtures_book()
+    books = Book.all.to_a
+    books.shift.dump_fixture(append = false)
+    for book in books do
+        book.dump_fixture
+    end
+end
 
+def fixtures_loan()
+    loans = Loan.all.to_a
+    loans.shift.dump_fixture(append = false)
+    for loan in loans do
+        loan.dump_fixture
+    end
+end
 
+def fixtures_user()
+    Loan.find(1).lent_by.dump_fixture(append=false)
+    Loan.find(1).loaned_by.dump_fixture
+    Loan.find(2).loaned_by.dump_fixture
+end
 
+def fixtures_review()
+    reviews = Review.all.to_a
+    reviews.shift.dump_fixture(append = false)
+    for review in reviews do
+        review.dump_fixture
+    end
+end
+
+case ENV["fixture"]
+when "all"
+    fixtures_book
+    fixtures_loan
+    fixtures_review
+    fixtures_title
+    fixtures_user
+when "book"
+    fixtures_book
+when "title"
+    fixtures_title
+when "loan"
+    fixtures_loan
+when "user"
+    fixtures_user
+when "review"
+    fixtures_review
+else
+    p "Error: Unsupported fixture flagg"
+end
 

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -119,6 +119,6 @@ when "user"
 when "review"
     fixtures_review
 else
-    p "Error: Unsupported fixture flagg"
+    p "Error: Unsupported fixture flag"
 end
 

--- a/backend/test/fixtures/books.yml
+++ b/backend/test/fixtures/books.yml
@@ -4,109 +4,123 @@ book_5000:
   barcode: '5000'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:36.873185000 Z
+    utc: &1 2019-12-18 14:23:28.051051000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.051051000 Z
     zone: *2
+    time: *3
+
+book_1001:
+  title_id: 3
+  barcode: '1001'
+  status: OK
+  created_at: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &1 2019-12-18 14:23:28.056364000 Z
+    zone: &2 !ruby/object:ActiveSupport::TimeZone
+      name: Etc/UTC
     time: *1
+  updated_at: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &3 2019-12-18 14:23:28.056364000 Z
+    zone: *2
+    time: *3
 
 book_5002:
   title_id: 1
   barcode: '5002'
   status: Broken
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.459715000 Z
+    utc: &1 2019-12-18 14:23:28.112119000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.112119000 Z
     zone: *2
-    time: *1
+    time: *3
 
 book_5003:
   title_id: 1
   barcode: '5003'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.465982000 Z
+    utc: &1 2019-12-18 14:23:28.117257000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.117257000 Z
     zone: *2
-    time: *1
+    time: *3
 
 book_5004:
   title_id: 2
   barcode: '5004'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.486053000 Z
+    utc: &1 2019-12-18 14:23:28.123696000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.123696000 Z
     zone: *2
-    time: *1
+    time: *3
 
 book_5005:
   title_id: 2
   barcode: '5005'
   status: Broken
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.492905000 Z
+    utc: &1 2019-12-18 14:23:28.129886000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.129886000 Z
     zone: *2
-    time: *1
+    time: *3
 
 book_5006:
   title_id: 3
   barcode: '5006'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.507037000 Z
+    utc: &1 2019-12-18 14:23:28.134007000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.134007000 Z
     zone: *2
-    time: *1
+    time: *3
 
 book_5007:
   title_id: 4
   barcode: '5007'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.514782000 Z
+    utc: &1 2019-12-18 14:23:28.138721000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.138721000 Z
     zone: *2
-    time: *1
+    time: *3
 
 book_5008:
   title_id: 4
   barcode: '5008'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.522068000 Z
+    utc: &1 2019-12-18 14:23:28.142569000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.142569000 Z
     zone: *2
-    time: *1
+    time: *3

--- a/backend/test/fixtures/loans.yml
+++ b/backend/test/fixtures/loans.yml
@@ -6,14 +6,14 @@ loan_1:
   book_id: '5000'
   returned_at: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:36.895809000 Z
+    utc: &1 2019-12-18 14:23:28.080520000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.080520000 Z
     zone: *2
-    time: *1
+    time: *3
   expiration_date: 2019-12-18
 
 loan_2:
@@ -23,12 +23,12 @@ loan_2:
   book_id: '1001'
   returned_at: 2019-12-18
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:36.904990000 Z
+    utc: &1 2019-12-18 14:23:28.092122000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.092122000 Z
     zone: *2
-    time: *1
+    time: *3
   expiration_date: 2019-12-18

--- a/backend/test/fixtures/reviews.yml
+++ b/backend/test/fixtures/reviews.yml
@@ -4,13 +4,13 @@ review_1:
   score: 3
   review: I didn't particulary like this book.
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:40.451666000 Z
+    utc: &1 2019-12-18 14:23:28.107291000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.107291000 Z
     zone: *2
-    time: *1
+    time: *3
   user_id: '1968097915'
   title_id: 1

--- a/backend/test/fixtures/titles.yml
+++ b/backend/test/fixtures/titles.yml
@@ -6,41 +6,20 @@ title_1:
   cost: 70
   title_type: Skönlitteratur
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:36.846290000 Z
+    utc: &1 2019-12-18 14:23:28.016944000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.016944000 Z
     zone: *2
-    time: *1
+    time: *3
   description: A little girl falls down a rabbit hole and discovers a world of nonsensical
     and amusing characters.
   authors: '["Lewis Carroll"]'
   cover: http://books.google.com/books/content?id=sw0UwPjaw80C&printsec=frontcover&img=1&zoom=3&source=gbs_api
   page_count: !ruby/object:BigDecimal 27:0.95e2
   published_date: '2009'
-
-title_3:
-  id: 3
-  name: Clean Code
-  isbn: '9780132350884'
-  cost: 300
-  title_type: Kurslitteratur
-  created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:36.854902000 Z
-    zone: &2 !ruby/object:ActiveSupport::TimeZone
-      name: Etc/UTC
-    time: *1
-  updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
-    zone: *2
-    time: *1
-  description: 
-  authors: 
-  cover: 
-  page_count: 
-  published_date: 
 
 title_2:
   id: 2
@@ -49,14 +28,35 @@ title_2:
   cost: 100
   title_type: Skönlitteratur
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:36.850766000 Z
+    utc: &1 2019-12-18 14:23:28.021793000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.021793000 Z
     zone: *2
+    time: *3
+  description: 
+  authors: 
+  cover: 
+  page_count: 
+  published_date: 
+
+title_3:
+  id: 3
+  name: Clean Code
+  isbn: '9780132350884'
+  cost: 300
+  title_type: Kurslitteratur
+  created_at: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &1 2019-12-18 14:23:28.028753000 Z
+    zone: &2 !ruby/object:ActiveSupport::TimeZone
+      name: Etc/UTC
     time: *1
+  updated_at: !ruby/object:ActiveSupport::TimeWithZone
+    utc: &3 2019-12-18 14:23:28.028753000 Z
+    zone: *2
+    time: *3
   description: 
   authors: 
   cover: 
@@ -70,14 +70,14 @@ title_4:
   cost: 60
   title_type: Kurslitteratur
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:36.858524000 Z
+    utc: &1 2019-12-18 14:23:28.034730000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: *1
+    utc: &3 2019-12-18 14:23:28.034730000 Z
     zone: *2
-    time: *1
+    time: *3
   description: 
   authors: 
   cover: 

--- a/backend/test/fixtures/users.yml
+++ b/backend/test/fixtures/users.yml
@@ -8,12 +8,12 @@ user_1954282603:
   google_token: '101173758873354282603'
   photo_path: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:28.997488000 Z
+    utc: &1 2019-12-18 14:23:19.877422000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 10:33:28.997488000 Z
+    utc: &3 2019-12-18 14:23:19.877422000 Z
     zone: *2
     time: *3
 
@@ -26,12 +26,12 @@ user_1968097915:
   google_token: '101834530373768097915'
   photo_path: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:31.445678000 Z
+    utc: &1 2019-12-18 14:23:22.610978000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 10:33:31.445678000 Z
+    utc: &3 2019-12-18 14:23:22.610978000 Z
     zone: *2
     time: *3
 
@@ -44,11 +44,11 @@ user_1975529089:
   google_token: '110102009585975529089'
   photo_path: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 10:33:33.510060000 Z
+    utc: &1 2019-12-18 14:23:24.607821000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 10:33:33.510060000 Z
+    utc: &3 2019-12-18 14:23:24.607821000 Z
     zone: *2
     time: *3


### PR DESCRIPTION
## What issue did you implement or fix?
Fixes #267 

## Summary
- Now doesn't automaticaly generate new fixtures on db:seed
- To generate fixtures run with flag 'fixture=WANTED_FIXTURE'
   example: bin/rails db:reset fixture=all
- Supports keyword all as well as single fixture, user book title etc.

## Type of change


- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## How can this implementation be improved?
- Some logic could most likely be optimized, ex switch statement.
