### PR TITLE
roleastext now able to take a user as input

### DIFF
--- a/frontend/src/helpers/RoleChecker.ts
+++ b/frontend/src/helpers/RoleChecker.ts
@@ -43,10 +43,10 @@ export default class RoleChecker {
     return UsersModule.currentUser && (UsersModule.currentUser.role & 1) == 1;
   }
 
-  static roleAsText(): string {
-    if (!UsersModule.currentUser) {return ''; }
+  static roleAsText(user: User = UsersModule.currentUser): string {
+    if (!user) {return ''; }
     for(const bitValue of Object.keys(roles).reverse()) {
-      if (UsersModule.currentUser.role >= Number(bitValue)) {
+      if (user.role >= Number(bitValue)) {
         return roles[Number(bitValue)];
       }
     }

--- a/frontend/src/helpers/__tests__/RoleChecker.spec.ts
+++ b/frontend/src/helpers/__tests__/RoleChecker.spec.ts
@@ -2,18 +2,19 @@ import UsersModule from '@/store/modules/UsersModule';
 import RoleChecker from '../RoleChecker';
 
 describe('RoleChecker.ts', () => {
-  it('translate roles correctly', () => {
-    const baseUser = {
-      role: 1, 
-      uid: 1111, 
-      created_at: '', //eslint-disable-line camelcase
-      email: '', 
-      google_token: '', //eslint-disable-line camelcase
-      klass: '', 
-      name: '', 
-      photo_path: '', //eslint-disable-line camelcase
-      updated_at: '' //eslint-disable-line camelcase
-    }; 
+  const baseUser = {
+    role: 1, 
+    uid: 1111, 
+    created_at: '', //eslint-disable-line camelcase
+    email: '', 
+    google_token: '', //eslint-disable-line camelcase
+    klass: '', 
+    name: '', 
+    photo_path: '', //eslint-disable-line camelcase
+    updated_at: '' //eslint-disable-line camelcase
+  }; 
+
+  it('translates current user roles correctly', () => {
     UsersModule.setUser(baseUser);
     UsersModule.setCurrentUser(baseUser);
     expect(RoleChecker.roleAsText()).toBe('Elev');
@@ -33,5 +34,16 @@ describe('RoleChecker.ts', () => {
     baseUser.role = 2;
     UsersModule.setUser(baseUser);
     expect(RoleChecker.roleAsText()).toBe('Elevhälsoteam');
+  });
+
+  it('translates input users correctly', () => {
+    baseUser.role = 8;
+    expect(RoleChecker.roleAsText(baseUser)).toBe('Vaktmästare');
+    
+    baseUser.role = 1;
+    expect(RoleChecker.roleAsText(baseUser)).toBe('Elev');
+
+    baseUser.role = 36;
+    expect(RoleChecker.roleAsText(baseUser)).toBe('Rektor');
   });
 });


### PR DESCRIPTION
## What issue did you implement or fix?
Fixes #294 

## Summary
- RoleAsText is now able to take a user as it's first argument.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## How can this implementation be improved?
- Im not sure if the checkPermission method should also be able to take a user but that is a probably a problem for the future.
