### PR TITLE
hotfixing hard coded user ids after new year uid updates

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -42,7 +42,7 @@ loan_alice.save
 
 loan_cc = Loan.new(expiration_date: Date.current)
 loan_cc.lent_by = User.find_by_name("Låneservice Johanneberg")
-loan_cc.loaned_by = User.find(1975529089)
+loan_cc.loaned_by = User.find(2075529089)
 loan_cc.book = book_cc
 loan_cc.returned_at = Date.current
 loan_cc.save

--- a/backend/test/controllers/users_controller_test.rb
+++ b/backend/test/controllers/users_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:user_1954282603)
+    @user = users(:user_2054282603)
   end
 
   test "should show user" do

--- a/backend/test/fixtures/books.yml
+++ b/backend/test/fixtures/books.yml
@@ -4,12 +4,12 @@ book_5000:
   barcode: '5000'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.051051000 Z
+    utc: &1 2020-01-08 09:34:35.165797000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.051051000 Z
+    utc: &3 2020-01-08 09:34:35.165797000 Z
     zone: *2
     time: *3
 
@@ -18,12 +18,12 @@ book_1001:
   barcode: '1001'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.056364000 Z
+    utc: &1 2020-01-08 09:34:35.169238000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.056364000 Z
+    utc: &3 2020-01-08 09:34:35.169238000 Z
     zone: *2
     time: *3
 
@@ -32,12 +32,12 @@ book_5002:
   barcode: '5002'
   status: Broken
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.112119000 Z
+    utc: &1 2020-01-08 09:34:35.203392000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.112119000 Z
+    utc: &3 2020-01-08 09:34:35.203392000 Z
     zone: *2
     time: *3
 
@@ -46,12 +46,12 @@ book_5003:
   barcode: '5003'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.117257000 Z
+    utc: &1 2020-01-08 09:34:35.206776000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.117257000 Z
+    utc: &3 2020-01-08 09:34:35.206776000 Z
     zone: *2
     time: *3
 
@@ -60,12 +60,12 @@ book_5004:
   barcode: '5004'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.123696000 Z
+    utc: &1 2020-01-08 09:34:35.210739000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.123696000 Z
+    utc: &3 2020-01-08 09:34:35.210739000 Z
     zone: *2
     time: *3
 
@@ -74,12 +74,12 @@ book_5005:
   barcode: '5005'
   status: Broken
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.129886000 Z
+    utc: &1 2020-01-08 09:34:35.214948000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.129886000 Z
+    utc: &3 2020-01-08 09:34:35.214948000 Z
     zone: *2
     time: *3
 
@@ -88,12 +88,12 @@ book_5006:
   barcode: '5006'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.134007000 Z
+    utc: &1 2020-01-08 09:34:35.218454000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.134007000 Z
+    utc: &3 2020-01-08 09:34:35.218454000 Z
     zone: *2
     time: *3
 
@@ -102,12 +102,12 @@ book_5007:
   barcode: '5007'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.138721000 Z
+    utc: &1 2020-01-08 09:34:35.221929000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.138721000 Z
+    utc: &3 2020-01-08 09:34:35.221929000 Z
     zone: *2
     time: *3
 
@@ -116,11 +116,11 @@ book_5008:
   barcode: '5008'
   status: OK
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.142569000 Z
+    utc: &1 2020-01-08 09:34:35.225170000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.142569000 Z
+    utc: &3 2020-01-08 09:34:35.225170000 Z
     zone: *2
     time: *3

--- a/backend/test/fixtures/loans.yml
+++ b/backend/test/fixtures/loans.yml
@@ -1,34 +1,34 @@
 
 loan_1:
   id: 1
-  loaned_by_id: 1968097915
-  lent_by_id: 1954282603
+  loaned_by_id: 2068097915
+  lent_by_id: 2054282603
   book_id: '5000'
   returned_at: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.080520000 Z
+    utc: &1 2020-01-08 09:34:35.182998000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.080520000 Z
+    utc: &3 2020-01-08 09:34:35.182998000 Z
     zone: *2
     time: *3
-  expiration_date: 2019-12-18
+  expiration_date: 2020-01-08
 
 loan_2:
   id: 2
-  loaned_by_id: 1975529089
-  lent_by_id: 1954282603
+  loaned_by_id: 2075529089
+  lent_by_id: 2054282603
   book_id: '1001'
-  returned_at: 2019-12-18
+  returned_at: 2020-01-08
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.092122000 Z
+    utc: &1 2020-01-08 09:34:35.190626000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.092122000 Z
+    utc: &3 2020-01-08 09:34:35.190626000 Z
     zone: *2
     time: *3
-  expiration_date: 2019-12-18
+  expiration_date: 2020-01-08

--- a/backend/test/fixtures/reviews.yml
+++ b/backend/test/fixtures/reviews.yml
@@ -4,13 +4,13 @@ review_1:
   score: 3
   review: I didn't particulary like this book.
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.107291000 Z
+    utc: &1 2020-01-08 09:34:35.200003000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.107291000 Z
+    utc: &3 2020-01-08 09:34:35.200003000 Z
     zone: *2
     time: *3
-  user_id: '1968097915'
+  user_id: '2068097915'
   title_id: 1

--- a/backend/test/fixtures/titles.yml
+++ b/backend/test/fixtures/titles.yml
@@ -6,12 +6,12 @@ title_1:
   cost: 70
   title_type: Skönlitteratur
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.016944000 Z
+    utc: &1 2020-01-08 09:34:35.134203000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.016944000 Z
+    utc: &3 2020-01-08 09:34:35.134203000 Z
     zone: *2
     time: *3
   description: A little girl falls down a rabbit hole and discovers a world of nonsensical
@@ -28,12 +28,12 @@ title_2:
   cost: 100
   title_type: Skönlitteratur
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.021793000 Z
+    utc: &1 2020-01-08 09:34:35.140421000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.021793000 Z
+    utc: &3 2020-01-08 09:34:35.140421000 Z
     zone: *2
     time: *3
   description: 
@@ -49,12 +49,12 @@ title_3:
   cost: 300
   title_type: Kurslitteratur
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.028753000 Z
+    utc: &1 2020-01-08 09:34:35.145128000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.028753000 Z
+    utc: &3 2020-01-08 09:34:35.145128000 Z
     zone: *2
     time: *3
   description: 
@@ -70,12 +70,12 @@ title_4:
   cost: 60
   title_type: Kurslitteratur
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:28.034730000 Z
+    utc: &1 2020-01-08 09:34:35.150847000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:28.034730000 Z
+    utc: &3 2020-01-08 09:34:35.150847000 Z
     zone: *2
     time: *3
   description: 

--- a/backend/test/fixtures/users.yml
+++ b/backend/test/fixtures/users.yml
@@ -1,6 +1,6 @@
 
-user_1954282603:
-  uid: 1954282603
+user_2054282603:
+  uid: 2054282603
   name: Låneservice Johanneberg
   email: johanneberg.laneservice@ga.ntig.se
   klass: ej
@@ -8,17 +8,17 @@ user_1954282603:
   google_token: '101173758873354282603'
   photo_path: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:19.877422000 Z
+    utc: &1 2020-01-08 09:34:27.859230000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:19.877422000 Z
+    utc: &3 2020-01-08 09:34:27.859230000 Z
     zone: *2
     time: *3
 
-user_1968097915:
-  uid: 1968097915
+user_2068097915:
+  uid: 2068097915
   name: Alex Henryz
   email: alex.henryz@elev.ga.ntig.se
   klass: TE4
@@ -26,17 +26,17 @@ user_1968097915:
   google_token: '101834530373768097915'
   photo_path: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:22.610978000 Z
+    utc: &1 2020-01-08 09:34:30.103766000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:22.610978000 Z
+    utc: &3 2020-01-08 09:34:30.103766000 Z
     zone: *2
     time: *3
 
-user_1975529089:
-  uid: 1975529089
+user_2075529089:
+  uid: 2075529089
   name: Max Gustafsson
   email: max.gustafsson@elev.ga.ntig.se
   klass: 3B
@@ -44,11 +44,11 @@ user_1975529089:
   google_token: '110102009585975529089'
   photo_path: 
   created_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &1 2019-12-18 14:23:24.607821000 Z
+    utc: &1 2020-01-08 09:34:32.147887000 Z
     zone: &2 !ruby/object:ActiveSupport::TimeZone
       name: Etc/UTC
     time: *1
   updated_at: !ruby/object:ActiveSupport::TimeWithZone
-    utc: &3 2019-12-18 14:23:24.607821000 Z
+    utc: &3 2020-01-08 09:34:32.147887000 Z
     zone: *2
     time: *3


### PR DESCRIPTION
## What issue did you implement or fix?

## Summary
- After the new year all user ids got changed (it is based on current year).
- This screwed with some hard coded id values.
- These values have been corrected in the backend tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## How can this implementation be improved?
- Not this implementation per say, but we need to change the way user ids are generated in the data fetch job. It is meant to be based on the year the user's account is created, not the current year
