### PR TITLE
fixed wrongly displayed error message

### DIFF
--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -118,6 +118,8 @@ when "user"
     fixtures_user
 when "review"
     fixtures_review
+when nil
+    #do nothing
 else
     p "Error: Unsupported fixture flag"
 end


### PR DESCRIPTION
## What issue did you implement or fix?
- Running the seeder gave an unacurate error

## Summary
- When you ran db:reset without fixture flag, it treated it as if you used an unsupported flag, therefor threw the error message: “Error: Unsupported fixture flag”.
- No flag and incorrect flag is now treated as separate cases and therefor no flag does not give an error.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## How can this implementation be improved?
- Change bar into zar. :shipit:
