### PR TITLE
admin/users load all users now instead of only teachers

### DIFF
--- a/frontend/src/views/AdminUsersView.vue
+++ b/frontend/src/views/AdminUsersView.vue
@@ -69,6 +69,10 @@ export default class AdminUsersVIew extends Vue {
   //       return user;
   //     }), 'uid');
   // }
+
+  /**
+   * This function loads all the users
+   */
   get allUsers(): UserCollection {
     let users = convertListToN(UsersModule.allAsArray
       .map((user) => {

--- a/frontend/src/views/AdminUsersView.vue
+++ b/frontend/src/views/AdminUsersView.vue
@@ -9,13 +9,13 @@
     />
     <v-data-table
       :headers="headers"
-      :items="convertListToA(staffUsers)"
+      :items="convertListToA(allUsers)"
       :items-per-page="5"
       :search="search"
     >
       <template v-slot:item.role="{ item }">
         <v-select
-          v-model="staffUsers[item.uid].assignedRoles"
+          v-model="allUsers[item.uid].assignedRoles"
           :items="selectRoles"
           multiple
         />
@@ -23,7 +23,7 @@
       <template v-slot:item.actions="{ item }">
         <v-btn 
           color="primary"
-          @click="updateUserRoles(staffUsers[item.uid])"
+          @click="updateUserRoles(allUsers[item.uid])"
         >
           Save
         </v-btn>
@@ -61,13 +61,21 @@ export default class AdminUsersVIew extends Vue {
    * This function filters out all students from the Usersmodule users
    * and gives the remaining an array with their specified roles.
    */
-  get staffUsers(): UserCollection {
-    return convertListToN(UsersModule.allAsArray
-      .filter(user => RoleChecker.isStudentHealth(user))
+  // get staffUsers(): UserCollection {
+  //   return convertListToN(UsersModule.allAsArray
+  //     .filter(user => RoleChecker.isStudentHealth(user))
+  //     .map((user) => {
+  //       user.assignedRoles = RoleChecker.assignedRoles(user).map((number) => { return number.toString(); });
+  //       return user;
+  //     }), 'uid');
+  // }
+  get allUsers(): UserCollection {
+    let users = convertListToN(UsersModule.allAsArray
       .map((user) => {
         user.assignedRoles = RoleChecker.assignedRoles(user).map((number) => { return number.toString(); });
         return user;
       }), 'uid');
+    return users;
   }
 
   private selectRoles: object[] = Object.keys(RoleChecker.roles()).map((key) => {
@@ -75,7 +83,7 @@ export default class AdminUsersVIew extends Vue {
       value: key, 
       text: RoleChecker.roles()[Number(key)] 
     }; 
-  }).filter(selectRole => Number(selectRole.value) != 1);
+  }).filter(selectRole => Number(selectRole.value));
   
   private created(): void {
     UsersModule.fetchAll();

--- a/frontend/src/views/AdminUsersView.vue
+++ b/frontend/src/views/AdminUsersView.vue
@@ -61,14 +61,6 @@ export default class AdminUsersVIew extends Vue {
    * This function filters out all students from the Usersmodule users
    * and gives the remaining an array with their specified roles.
    */
-  // get staffUsers(): UserCollection {
-  //   return convertListToN(UsersModule.allAsArray
-  //     .filter(user => RoleChecker.isStudentHealth(user))
-  //     .map((user) => {
-  //       user.assignedRoles = RoleChecker.assignedRoles(user).map((number) => { return number.toString(); });
-  //       return user;
-  //     }), 'uid');
-  // }
 
   /**
    * This function loads all the users

--- a/frontend/src/views/AdminUsersView.vue
+++ b/frontend/src/views/AdminUsersView.vue
@@ -57,7 +57,6 @@ export default class AdminUsersVIew extends Vue {
     { text: 'Roller', value: 'role' },
     { text: '', value: 'actions' },
   ];
-  /**
   get allUsers(): UserCollection {
     let users = convertListToN(UsersModule.allAsArray
       .map((user) => {

--- a/frontend/src/views/AdminUsersView.vue
+++ b/frontend/src/views/AdminUsersView.vue
@@ -58,9 +58,6 @@ export default class AdminUsersVIew extends Vue {
     { text: '', value: 'actions' },
   ];
   /**
-   * This function filters out all students from the Usersmodule users
-   * and gives the remaining an array with their specified roles.
-   */
 
   /**
    * This function loads all the users

--- a/frontend/src/views/AdminUsersView.vue
+++ b/frontend/src/views/AdminUsersView.vue
@@ -58,10 +58,6 @@ export default class AdminUsersVIew extends Vue {
     { text: '', value: 'actions' },
   ];
   /**
-
-  /**
-   * This function returns all users
-   */
   get allUsers(): UserCollection {
     let users = convertListToN(UsersModule.allAsArray
       .map((user) => {

--- a/frontend/src/views/AdminUsersView.vue
+++ b/frontend/src/views/AdminUsersView.vue
@@ -60,7 +60,7 @@ export default class AdminUsersVIew extends Vue {
   /**
 
   /**
-   * This function loads all the users
+   * This function returns all users
    */
   get allUsers(): UserCollection {
     let users = convertListToN(UsersModule.allAsArray


### PR DESCRIPTION
## ⚙️ What issue did you implement or fix?
Fixes #418 

## 📜 Summary
- Added the ability to view all users in /admin/users instead of only teachers.

## 📝 Type of change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature or enhancement (non-breaking change which adds functionality)


## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 💩 How can this implementation be improved?
- Could use some testing
