### PR TITLE
Revert "Fixed the TitleForm interface"

### DIFF
--- a/frontend/src/components/TitleFormComponent.vue
+++ b/frontend/src/components/TitleFormComponent.vue
@@ -137,7 +137,7 @@ export default defineComponent({
       cost: '',
       isbn: '',
       title_type: '', //eslint-disable-line camelcase
-      subject_id?: null,  //eslint-disable-line camelcase
+      subject_id: '',  //eslint-disable-line camelcase
     } as TitleForm);
 
     let buttonText = '';

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -56,7 +56,6 @@ interface TitleForm {
   cost: string;
   isbn: string;
   title_type: string; //eslint-disable-line camelcase
-  subject_id: number; //eslint-disable-line camelcase
 }
 
 interface TitleCollection { [id: number]: Title; }


### PR DESCRIPTION
Reverts itggot-TE4/Yabs#737

An object member can't be declared optional