### PR TITLE
Added breaks for the switch to solve button text error

### DIFF
--- a/frontend/src/components/TitleFormComponent.vue
+++ b/frontend/src/components/TitleFormComponent.vue
@@ -142,9 +142,15 @@ export default defineComponent({
 
     let buttonText = '';
     switch(props.mode) {
-      case 'new':  buttonText = 'Lägg till';
-      case 'edit': buttonText = 'Uppdatera titel';
-      default:     buttonText = 'Unknown form mode';
+      case 'new':  
+        buttonText = 'Lägg till';
+        break;
+      case 'edit': 
+        buttonText = 'Uppdatera titel';
+        break;
+      default:     
+        buttonText = 'Okänt formulär';
+        break;
     }
 
     if (props.formData != null) {


### PR DESCRIPTION
## ⚙️ What issue did you implement or fix?
Fixes #746 

## 📜 Summary
- Added missing breaks in the switch-case to solve the button text appearing incorrectly

## 📝 Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes